### PR TITLE
added class_enrolled and class_taught sql schema

### DIFF
--- a/server/db/schema/class_enrollments.sql
+++ b/server/db/schema/class_enrollments.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS class_enrollments (
-    id SERIAL PRIMARY KEY,
+    id SERIAL,
     student_id INTEGER NOT NULL,
     class_id INTEGER NOT NULL,
     attendance DATE NOT NULL,
@@ -8,9 +8,12 @@ CREATE TABLE IF NOT EXISTS class_enrollments (
         FOREIGN KEY(student_id)
         REFERENCES student(id)
         ON DELETE CASCADE,
+
+    CONSTRAINT Pk_student_class_id
+        PRIMARY KEY(student_id, class_id, id),
     
     CONSTRAINT fk_class
         FOREIGN KEY(class_id)
         REFERENCES classes(id)
-        ON DELETE CASCADE 
+        ON DELETE CASCADE
 )

--- a/server/db/schema/class_enrollments.sql
+++ b/server/db/schema/class_enrollments.sql
@@ -4,13 +4,13 @@ CREATE TABLE IF NOT EXISTS class_enrollments (
     class_id INTEGER NOT NULL,
     attendance DATE NOT NULL,
 
+    CONSTRAINT Pk_class_enrollments
+        PRIMARY KEY(student_id, class_id, id),
+
     CONSTRAINT fk_student
         FOREIGN KEY(student_id)
         REFERENCES student(id)
         ON DELETE CASCADE,
-
-    CONSTRAINT Pk_student_class_id
-        PRIMARY KEY(student_id, class_id, id),
     
     CONSTRAINT fk_class
         FOREIGN KEY(class_id)

--- a/server/db/schema/class_enrollments.sql
+++ b/server/db/schema/class_enrollments.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS class_enrollments (
+    id SERIAL PRIMARY KEY,
+    student_id INT NOT NULL,
+    class_id INT NOT NULL,
+    attendance DATE NOT NULL,
+
+    CONSTRAINT fk_student
+        FOREIGN KEY(student_id)
+        REFERENCES student(id)
+        ON DELETE CASCADE,
+    
+    CONSTRAINT fk_class
+        FOREIGN KEY(class_id)
+        REFERENCES classes(id)
+        ON DELETE CASCADE 
+)

--- a/server/db/schema/class_enrollments.sql
+++ b/server/db/schema/class_enrollments.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS class_enrollments (
     id SERIAL PRIMARY KEY,
-    student_id INT NOT NULL,
-    class_id INT NOT NULL,
+    student_id INTEGER NOT NULL,
+    class_id INTEGER NOT NULL,
     attendance DATE NOT NULL,
 
     CONSTRAINT fk_student

--- a/server/db/schema/classes_taught.sql
+++ b/server/db/schema/classes_taught.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS classes_taught (
+    class_id INT NOT NULL,
+    teacher_id INT NOT NULL,
+    
+    CONSTRAINT fk_class
+        FOREIGN KEY(class_id)
+        REFERENCES classes(id)
+        ON DELETE CASCADE
+    
+    CONSTRAINT fk_teacher
+        FOREIGN KEY(teacher_id)
+        REFERENCES teacher(id)
+        ON DELETE CASCADE
+)

--- a/server/db/schema/classes_taught.sql
+++ b/server/db/schema/classes_taught.sql
@@ -7,6 +7,9 @@ CREATE TABLE IF NOT EXISTS classes_taught (
         REFERENCES classes(id)
         ON DELETE CASCADE,
     
+    CONSTRAINT Pk_class_id_teacher_id
+        PRIMARY KEY(class_id, teacher_id),
+    
     CONSTRAINT fk_teacher
         FOREIGN KEY(teacher_id)
         REFERENCES teacher(id)

--- a/server/db/schema/classes_taught.sql
+++ b/server/db/schema/classes_taught.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS classes_taught (
-    class_id INT NOT NULL,
-    teacher_id INT NOT NULL,
+    class_id INTEGER NOT NULL,
+    teacher_id INTEGER NOT NULL,
     
     CONSTRAINT fk_class
         FOREIGN KEY(class_id)

--- a/server/db/schema/classes_taught.sql
+++ b/server/db/schema/classes_taught.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS classes_taught (
     CONSTRAINT fk_class
         FOREIGN KEY(class_id)
         REFERENCES classes(id)
-        ON DELETE CASCADE
+        ON DELETE CASCADE,
     
     CONSTRAINT fk_teacher
         FOREIGN KEY(teacher_id)

--- a/server/db/schema/classes_taught.sql
+++ b/server/db/schema/classes_taught.sql
@@ -2,13 +2,13 @@ CREATE TABLE IF NOT EXISTS classes_taught (
     class_id INTEGER NOT NULL,
     teacher_id INTEGER NOT NULL,
     
+    CONSTRAINT Pk_classes_taught
+        PRIMARY KEY(class_id, teacher_id),
+
     CONSTRAINT fk_class
         FOREIGN KEY(class_id)
         REFERENCES classes(id)
         ON DELETE CASCADE,
-    
-    CONSTRAINT Pk_class_id_teacher_id
-        PRIMARY KEY(class_id, teacher_id),
     
     CONSTRAINT fk_teacher
         FOREIGN KEY(teacher_id)


### PR DESCRIPTION
## Description
Added `class_enrolled.sql` and `class_taught.sql` SQL Schemas

## Screenshots/Media
![image](https://github.com/user-attachments/assets/9613e267-3b13-4209-8a89-e27cb1ab7aad)

## Issues
Closes #6

<!-- [Optional]
## Additional Notes
-->
Used documentation from Neon.Tech on how to [create foreign key constraints](https://neon.tech/postgresql/postgresql-tutorial/postgresql-foreign-key) and how to [create integer primary key](https://neon.tech/postgresql/postgresql-tutorial/postgresql-primary-key). 

Tested on a test database on neon.tech and there is no syntax error.

## Assumptions

1. The primary key will be auto-increment
2. Using CASCADE when deleting a row (to handle foreign key and NOT NULL constraint)